### PR TITLE
Ptr{None} -> Ptr{Void}

### DIFF
--- a/examples/9_PermutationExamples.jl
+++ b/examples/9_PermutationExamples.jl
@@ -22,7 +22,7 @@ end
 println()
      
 print(" random permutation:")  
-ran_shuffle(r, convert(Ptr{None}, unsafe_ref(p).data), N, sizeof(Uint64))
+ran_shuffle(r, convert(Ptr{Void}, unsafe_ref(p).data), N, sizeof(Uint64))
 #permutation_fprintf(stdout, p, " %u")
 for x in pointer_to_array(unsafe_ref(p).data, (int(unsafe_ref(p).size),))
     print(int(x), " ")


### PR DESCRIPTION
Ptr{None} is deprecated, see https://github.com/JuliaLang/julia/issues/8423

Please check that this is correct, I just searched for usages in packages registered in METADATA, and might have made mistakes.
