### PR TITLE
Remove deprecated functions, fix #53

### DIFF
--- a/gen/makewrappers.jl
+++ b/gen/makewrappers.jl
@@ -33,7 +33,8 @@ ignore_header(filename) = any(endswith.(filename, ignore_headers))
 ignore_list_prefix = ["gsl_blas", "gsl_eigen_", "gsl_sort", "cblas_", "gsl_fft_", "gsl_linalg_"]
 ignore_list = ["gsl_asinh", "gsl_atanh", "gsl_error", "gsl_expm1", "gsl_frexp",
                "gsl_hypot", "gsl_isinf", "gsl_isnan", "gsl_ldexp", "gsl_log1p",
-               "gsl_max", "gsl_min", "gsl_acosh"]
+               "gsl_max", "gsl_min", "gsl_acosh",
+               "gsl_sf_legendre_Plm_array", "gsl_sf_legendre_Plm_deriv_array"]
 ignore_this(name) = any(startswith.(name, ignore_list_prefix)) || (name in ignore_list)
 
 type_match = Dict(

--- a/src/gen/direct_wrappers/gsl_sf_legendre_h.jl
+++ b/src/gen/direct_wrappers/gsl_sf_legendre_h.jl
@@ -265,38 +265,6 @@ function sf_legendre_Plm(l, m, x)
 end
 
 @doc md"""
-    sf_legendre_Plm_array(lmax, m, x, result_array) -> Cint
-
-C signature:
-`int gsl_sf_legendre_Plm_array( const int lmax, const int m, const double x, double * result_array )`
-
-GSL documentation:
-
-### `int gsl_sf_legendre_Plm_array (int lmax, int m, double x, double result_array[])`
-
-> int gsl\_sf\_legendre\_Plm\_deriv\_array (int lmax, int m, double x,
-> double result\_array\[\], double result\_deriv\_array\[\])
-
-> These functions are now deprecated and will be removed in a future
-> release; see `gsl_sf_legendre_array` and
-> `gsl_sf_legendre_deriv_array`.
-
-"""
-function sf_legendre_Plm_array(lmax, m, x, result_array)
-    ccall((:gsl_sf_legendre_Plm_array, libgsl), Cint, (Cint, Cint, Cdouble, Ref{Cdouble}), lmax, m, x, result_array)
-end
-
-@doc md"""
-    sf_legendre_Plm_deriv_array(lmax, m, x, result_array, result_deriv_array) -> Cint
-
-C signature:
-`int gsl_sf_legendre_Plm_deriv_array( const int lmax, const int m, const double x, double * result_array, double * result_deriv_array )`
-"""
-function sf_legendre_Plm_deriv_array(lmax, m, x, result_array, result_deriv_array)
-    ccall((:gsl_sf_legendre_Plm_deriv_array, libgsl), Cint, (Cint, Cint, Cdouble, Ref{Cdouble}, Ref{Cdouble}), lmax, m, x, result_array, result_deriv_array)
-end
-
-@doc md"""
     sf_legendre_sphPlm_e(l, m, x, result) -> Cint
 
 C signature:

--- a/src/gen/gsl_export.jl
+++ b/src/gen/gsl_export.jl
@@ -3365,8 +3365,6 @@ export sf_legendre_Ql_e
 export sf_legendre_Ql
 export sf_legendre_Plm_e
 export sf_legendre_Plm
-export sf_legendre_Plm_array
-export sf_legendre_Plm_deriv_array
 export sf_legendre_sphPlm_e
 export sf_legendre_sphPlm
 export sf_legendre_sphPlm_array

--- a/src/gen/heuristic_wrappers.jl
+++ b/src/gen/heuristic_wrappers.jl
@@ -3730,45 +3730,6 @@ function sf_legendre_Plm_e(l, m, x)
     return result
 end
 
-export sf_legendre_Plm_array
-@doc md"""
-    sf_legendre_Plm_array(lmax, m, x) -> Array{Float64}
-
-C signature:
-`int gsl_sf_legendre_Plm_array( const int lmax, const int m, const double x, double * result_array )`
-
-GSL documentation:
-
-### `int gsl_sf_legendre_Plm_array (int lmax, int m, double x, double result_array[])`
-
-> int gsl\_sf\_legendre\_Plm\_deriv\_array (int lmax, int m, double x,
-> double result\_array\[\], double result\_deriv\_array\[\])
-
-> These functions are now deprecated and will be removed in a future
-> release; see `gsl_sf_legendre_array` and
-> `gsl_sf_legendre_deriv_array`.
-
-"""
-function sf_legendre_Plm_array(lmax, m, x)
-    result_array = zeros(Cdouble, (lmax+1))
-    output = C.sf_legendre_Plm_array(lmax, m, x, result_array)
-    return result_array
-end
-
-export sf_legendre_Plm_deriv_array
-@doc md"""
-    sf_legendre_Plm_deriv_array(lmax, m, x) -> (Array{Float64}, Array{Float64})
-
-C signature:
-`int gsl_sf_legendre_Plm_deriv_array( const int lmax, const int m, const double x, double * result_array, double * result_deriv_array )`
-"""
-function sf_legendre_Plm_deriv_array(lmax, m, x)
-    result_array = zeros(Cdouble, (lmax+1))
-    result_deriv_array = zeros(Cdouble, (lmax+1))
-    output = C.sf_legendre_Plm_deriv_array(lmax, m, x, result_array, result_deriv_array)
-    return result_array, result_deriv_array
-end
-
 export sf_legendre_sphPlm_e
 @doc md"""
     sf_legendre_sphPlm_e(l, m, x) -> gsl_sf_result


### PR DESCRIPTION
The following functions were defined in the headers but missing from the library:
- gsl_sf_legendre_Plm_array
- gsl_sf_legendre_Plm_deriv_array