### PR TITLE
Add Cirrus script to test the package on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.1
+      - JULIA_VERSION: nightly
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test

--- a/test/specfunc.jl
+++ b/test/specfunc.jl
@@ -32,10 +32,10 @@ using Test
         specfun_compare("besselI0", x -> besseli(0, x), sf_bessel_I0, x )
         specfun_compare("besselI1", x -> besseli(1, x), sf_bessel_I1, x )
         for i=0:10
-            specfun_compare("besselIn($i)", x -> besseli(i, x), x -> sf_bessel_In(i, x), x )        
+            specfun_compare("besselIn($i)", x -> besseli(i, x), x -> sf_bessel_In(i, x), x, rtol=15*eps() )        
         end
         for i=0:10
-            specfun_compare("besselInu($i)", x -> besselix(i, x), x -> sf_bessel_Inu_scaled(i, x), x )        
+            specfun_compare("besselInu($i)", x -> besselix(i, x), x -> sf_bessel_Inu_scaled(i, x), x, rtol=15*eps() )        
         end
 
         specfun_compare("besselJ0", besselj0, sf_bessel_J0, x )
@@ -44,7 +44,7 @@ using Test
             specfun_compare("besselJn($i)", x -> besselj(i, x), x -> sf_bessel_Jn(i, x), x )        
         end
         for i=0:10
-            specfun_compare("besselJnu($i)", x -> besseljx(i, x), x -> sf_bessel_Jnu(i, x), x )        
+            specfun_compare("besselJnu($i)", x -> besseljx(i, x), x -> sf_bessel_Jnu(i, x), x, rtol=15*eps() )        
         end
 
         specfun_compare("besselK0", x -> besselk(0, x), sf_bessel_K0, x )


### PR DESCRIPTION
If someone with admin rights on this repo con [install Cirrus](https://github.com/marketplace/cirrus-ci), this PR enables testing for FreeBSD, which can be particularly useful for a package depending on a binary artifact.  Based on the [script](https://github.com/JuliaMath/SpecialFunctions.jl/blob/d8727a02d4cc5b34d2b3a1525c86869ef2a1104a/.cirrus.yml) for `SpecialFunctions.jl`