### PR TITLE
Allow SpecialFunctions v0.9 and v0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ GSL_jll = "1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
-SpecialFunctions = "0.8.0"
+SpecialFunctions = "0.8, 0.9, 0.10"
 GSL_jll = "2.6"
 julia = "1.3.0"
 

--- a/src/GSL.jl
+++ b/src/GSL.jl
@@ -10,9 +10,6 @@ using Markdown
 using Libdl
 using GSL_jll
 
-const libgslcblas = joinpath(dirname(GSL_jll.libgsl_path),
-                             "libgslcblas" * (Sys.iswindows() ? "-0." : "." ) * dlext)
-
 # Generated code
 include("gen/gsl_export.jl")
 include("gen/gsl_types.jl")
@@ -24,7 +21,7 @@ include("error_handling.jl")
 function __init__()
     # Seems we need to load BLAS with this RTLD_GLOBAL
     flags = Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL
-    if Libdl.dlopen_e(libgslcblas, flags) in (C_NULL, nothing)
+    if Libdl.dlopen_e(GSL_jll.libgslcblas_path, flags) in (C_NULL, nothing)
         error("$(libgslcblas) cannot be opened, Please re-run Pkg.build(\"GSL\"), and restart Julia.")
     end    
     # # Turn off default error handler

--- a/test/error.jl
+++ b/test/error.jl
@@ -1,18 +1,11 @@
 using Test
 import GSL
 
-@testset "Error Handling" begin
-    @info "Testing error handler..."
-    try
-        GSL.vector_alloc(typemax(Csize_t)) 
-    catch e
-        @test typeof(e) == OutOfMemoryError
-    end
+# This is only needed to make `@test_logs` work with the custom error handling
+# of GSL.jl
+Base.occursin(r::Regex, err::GSL.C.GSLError) = occursin(r, repr(err))
 
-    @info "Testing error handler..."    
-    try
-        sf_hyperg_2F1(1,2,3,4)
-    catch e
-        @test typeof(e) == DomainError
-    end
+@testset "Error Handling" begin
+    @test_logs (:warn, r"GSL Error 8") @test_throws OutOfMemoryError GSL.vector_alloc(typemax(Csize_t))
+    @test_logs (:warn, r"GSL Error 1") @test_throws DomainError      sf_hyperg_2F1(1,2,3,4)
 end


### PR DESCRIPTION
Also, simplify testing of error handling and avoid defining `libgslcblas`
variable.