### PR TITLE
Proper handling of some callbacks and create some wrapper objects with automatic memory management

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "1.0.1"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 GSL_jll = "1b77fbbe-d8ee-58f0-85f9-836ddc23a7a4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
 SpecialFunctions = "0.8, 0.9, 0.10, 1"
 GSL_jll = "2.6"
+REPL = "1.3.0"
 julia = "1.3.0"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ GSL.C.sf_legendre_array(GSL_SF_LEGENDRE_SPHARM, lmax, x, result)
 ```julia
 f = x -> x^5+1
 df = x -> 5*x^4
-fdf = @gsl_function_fdf(f, df)
-solver = root_fdfsolver_alloc(gsl_root_fdfsolver_newton)
-root_fdfsolver_set(solver, fdf, -2)
+solver = GSLRootFDFSolver(gsl_root_fdfsolver_newton)
+root_fdfsolver_set(solver, (f, df), -2)
 while abs(f(root_fdfsolver_root(solver))) > 1e-10
     root_fdfsolver_iterate(solver)
 end
@@ -87,7 +86,6 @@ println("x = ", root_fdfsolver_root(solver))
 Extra functionality defined in this package:
 
 * Convenience functions `hypergeom` and `hypergeom_e` for the hypergeometric functions.
-* Function wrapping macros `@gsl_function`, `@gsl_function_fdf`, `@gsl_multiroot_function` and `@gsl_multiroot_function_fdf` that are used for packaging Julia functions so that they can be passed to GSL.
 * Functions `wrap_gsl_vector` and `wrap_gsl_matrix` that return a Julia array or matrix pointing to the data in a `gsl_vector` or `gsl_matrix`.
 
 In addition, some effort has been put into giving most types and functions proper docstrings, e.g.

--- a/src/GSL.jl
+++ b/src/GSL.jl
@@ -1,6 +1,7 @@
 module GSL
 
 using Markdown
+using REPL # For Docs.doc
 
 # BEGIN MODULE C
 # low-level interface

--- a/src/gen/direct_wrappers/gsl_chebyshev_h.jl
+++ b/src/gen/direct_wrappers/gsl_chebyshev_h.jl
@@ -57,7 +57,7 @@ GSL documentation:
 > and requires $n$ function evaluations.
 
 """
-function cheb_init(cs, func, a, b)
+function cheb_init(cs, func::gsl_function, a, b)
     ccall((:gsl_cheb_init, libgsl), Cint, (Ref{gsl_cheb_series}, Ref{gsl_function}, Cdouble, Cdouble), cs, func, a, b)
 end
 

--- a/src/gen/direct_wrappers/gsl_deriv_h.jl
+++ b/src/gen/direct_wrappers/gsl_deriv_h.jl
@@ -32,7 +32,7 @@ GSL documentation:
 > actually used.
 
 """
-function deriv_central(f, x, h, result, abserr)
+function deriv_central(f::F, x, h, result, abserr) where F
     ccall((:gsl_deriv_central, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, h, result, abserr)
 end
 
@@ -58,7 +58,7 @@ GSL documentation:
 > negative step-size.
 
 """
-function deriv_backward(f, x, h, result, abserr)
+function deriv_backward(f::F, x, h, result, abserr) where F
     ccall((:gsl_deriv_backward, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, h, result, abserr)
 end
 
@@ -89,7 +89,7 @@ GSL documentation:
 > $x+h/2$, $x+h$.
 
 """
-function deriv_forward(f, x, h, result, abserr)
+function deriv_forward(f::F, x, h, result, abserr) where F
     ccall((:gsl_deriv_forward, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, h, result, abserr)
 end
 

--- a/src/gen/direct_wrappers/gsl_diff_h.jl
+++ b/src/gen/direct_wrappers/gsl_diff_h.jl
@@ -12,7 +12,7 @@
 C signature:
 `int gsl_diff_central (const gsl_function *f, double x, double *result, double *abserr)`
 """
-function diff_central(f, x, result, abserr)
+function diff_central(f::F, x, result, abserr) where F
     ccall((:gsl_diff_central, libgsl), Cint, (Ref{gsl_function}, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, result, abserr)
 end
 
@@ -22,7 +22,7 @@ end
 C signature:
 `int gsl_diff_backward (const gsl_function *f, double x, double *result, double *abserr)`
 """
-function diff_backward(f, x, result, abserr)
+function diff_backward(f::F, x, result, abserr) where F
     ccall((:gsl_diff_backward, libgsl), Cint, (Ref{gsl_function}, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, result, abserr)
 end
 
@@ -32,7 +32,7 @@ end
 C signature:
 `int gsl_diff_forward (const gsl_function *f, double x, double *result, double *abserr)`
 """
-function diff_forward(f, x, result, abserr)
+function diff_forward(f::F, x, result, abserr) where F
     ccall((:gsl_diff_forward, libgsl), Cint, (Ref{gsl_function}, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, x, result, abserr)
 end
 

--- a/src/gen/direct_wrappers/gsl_integration_h.jl
+++ b/src/gen/direct_wrappers/gsl_integration_h.jl
@@ -253,7 +253,7 @@ end
 C signature:
 `void gsl_integration_qk15 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk15(f, a, b, result, abserr, resabs, resasc)
+function integration_qk15(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk15, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -263,7 +263,7 @@ end
 C signature:
 `void gsl_integration_qk21 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk21(f, a, b, result, abserr, resabs, resasc)
+function integration_qk21(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk21, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -273,7 +273,7 @@ end
 C signature:
 `void gsl_integration_qk31 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk31(f, a, b, result, abserr, resabs, resasc)
+function integration_qk31(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk31, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -283,7 +283,7 @@ end
 C signature:
 `void gsl_integration_qk41 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk41(f, a, b, result, abserr, resabs, resasc)
+function integration_qk41(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk41, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -293,7 +293,7 @@ end
 C signature:
 `void gsl_integration_qk51 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk51(f, a, b, result, abserr, resabs, resasc)
+function integration_qk51(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk51, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -303,7 +303,7 @@ end
 C signature:
 `void gsl_integration_qk61 (const gsl_function * f, double a, double b, double *result, double *abserr, double *resabs, double *resasc)`
 """
-function integration_qk61(f, a, b, result, abserr, resabs, resasc)
+function integration_qk61(f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk61, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -313,7 +313,7 @@ end
 C signature:
 `void gsl_integration_qcheb (gsl_function * f, double a, double b, double *cheb12, double *cheb24)`
 """
-function integration_qcheb(f, a, b, cheb12, cheb24)
+function integration_qcheb(f::F, a, b, cheb12, cheb24) where F
     ccall((:gsl_integration_qcheb, libgsl), Cvoid, (Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}), f, a, b, cheb12, cheb24)
 end
 
@@ -323,7 +323,7 @@ end
 C signature:
 `void gsl_integration_qk (const int n, const double xgk[], const double wg[], const double wgk[], double fv1[], double fv2[], const gsl_function *f, double a, double b, double * result, double * abserr, double * resabs, double * resasc)`
 """
-function integration_qk(n, xgk, wg, wgk, fv1, fv2, f, a, b, result, abserr, resabs, resasc)
+function integration_qk(n, xgk, wg, wgk, fv1, fv2, f::F, a, b, result, abserr, resabs, resasc) where F
     ccall((:gsl_integration_qk, libgsl), Cvoid, (Cint, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{gsl_function}, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}), n, xgk, wg, wgk, fv1, fv2, f, a, b, result, abserr, resabs, resasc)
 end
 
@@ -348,7 +348,7 @@ GSL documentation:
 > of function evaluations.
 
 """
-function integration_qng(f, a, b, epsabs, epsrel, result, abserr, neval)
+function integration_qng(f::F, a, b, epsabs, epsrel, result, abserr, neval) where F
     ccall((:gsl_integration_qng, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Ref{Cdouble}, Ref{Cdouble}, Ref{Csize_t}), f, a, b, epsabs, epsrel, result, abserr, neval)
 end
 
@@ -394,7 +394,7 @@ GSL documentation:
 > allocated size of the workspace.
 
 """
-function integration_qag(f, a, b, epsabs, epsrel, limit, key, workspace, result, abserr)
+function integration_qag(f::F, a, b, epsabs, epsrel, limit, key, workspace, result, abserr) where F
     ccall((:gsl_integration_qag, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Csize_t, Cint, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, epsabs, epsrel, limit, key, workspace, result, abserr)
 end
 
@@ -420,7 +420,7 @@ GSL documentation:
 > In this case a lower-order rule is more efficient.
 
 """
-function integration_qagi(f, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qagi(f::F, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qagi, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -443,7 +443,7 @@ GSL documentation:
 > and then integrated using the QAGS algorithm.
 
 """
-function integration_qagiu(f, a, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qagiu(f::F, a, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qagiu, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, a, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -466,7 +466,7 @@ GSL documentation:
 > and then integrated using the QAGS algorithm.
 
 """
-function integration_qagil(f, b, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qagil(f::F, b, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qagil, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, b, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -493,7 +493,7 @@ GSL documentation:
 > which may not exceed the allocated size of the workspace.
 
 """
-function integration_qags(f, a, b, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qags(f::F, a, b, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qags, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -527,7 +527,7 @@ GSL documentation:
 > region then this routine will be faster than `gsl_integration_qags`.
 
 """
-function integration_qagp(f, pts, npts, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qagp(f::F, pts, npts, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qagp, libgsl), Cint, (Ref{gsl_function}, Ref{Cdouble}, Csize_t, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, pts, npts, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -566,7 +566,7 @@ GSL documentation:
 > ordinary 15-point Gauss-Kronrod integration rule.
 
 """
-function integration_qawc(f, a, b, c, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qawc(f::F, a, b, c, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qawc, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, c, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -595,7 +595,7 @@ GSL documentation:
 > Gauss-Kronrod integration rule is used.
 
 """
-function integration_qaws(f, a, b, t, epsabs, epsrel, limit, workspace, result, abserr)
+function integration_qaws(f::F, a, b, t, epsabs, epsrel, limit, workspace, result, abserr) where F
     ccall((:gsl_integration_qaws, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Ref{gsl_integration_qaws_table}, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{Cdouble}, Ref{Cdouble}), f, a, b, t, epsabs, epsrel, limit, workspace, result, abserr)
 end
 
@@ -645,7 +645,7 @@ GSL documentation:
 > integration.
 
 """
-function integration_qawo(f, a, epsabs, epsrel, limit, workspace, wf, result, abserr)
+function integration_qawo(f::F, a, epsabs, epsrel, limit, workspace, wf, result, abserr) where F
     ccall((:gsl_integration_qawo, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{gsl_integration_qawo_table}, Ref{Cdouble}, Ref{Cdouble}), f, a, epsabs, epsrel, limit, workspace, wf, result, abserr)
 end
 
@@ -737,7 +737,7 @@ GSL documentation:
 > `cycle_workspace` as workspace for the QAWO algorithm.
 
 """
-function integration_qawf(f, a, epsabs, limit, workspace, cycle_workspace, wf, result, abserr)
+function integration_qawf(f::F, a, epsabs, limit, workspace, cycle_workspace, wf, result, abserr) where F
     ccall((:gsl_integration_qawf, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Csize_t, Ref{gsl_integration_workspace}, Ref{gsl_integration_workspace}, Ref{gsl_integration_qawo_table}, Ref{Cdouble}, Ref{Cdouble}), f, a, epsabs, limit, workspace, cycle_workspace, wf, result, abserr)
 end
 
@@ -793,7 +793,7 @@ GSL documentation:
 > table `t` and returns the result.
 
 """
-function integration_glfixed(f, a, b, t)
+function integration_glfixed(f::F, a, b, t) where F
     ccall((:gsl_integration_glfixed, libgsl), Cdouble, (Ref{gsl_function}, Cdouble, Cdouble, Ref{gsl_integration_glfixed_table}), f, a, b, t)
 end
 
@@ -890,7 +890,7 @@ GSL documentation:
 > set to `NULL`.
 
 """
-function integration_cquad(f, a, b, epsabs, epsrel, ws, result, abserr, nevals)
+function integration_cquad(f::F, a, b, epsabs, epsrel, ws, result, abserr, nevals) where F
     ccall((:gsl_integration_cquad, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Ref{gsl_integration_cquad_workspace}, Ref{Cdouble}, Ref{Cdouble}, Ref{Csize_t}), f, a, b, epsabs, epsrel, ws, result, abserr, nevals)
 end
 
@@ -957,7 +957,7 @@ GSL documentation:
 > `neval`.
 
 """
-function integration_romberg(f, a, b, epsabs, epsrel, result, neval, w)
+function integration_romberg(f::F, a, b, epsabs, epsrel, result, neval, w) where F
     ccall((:gsl_integration_romberg, libgsl), Cint, (Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Ref{Cdouble}, Ref{Csize_t}, Ref{gsl_integration_romberg_workspace}), f, a, b, epsabs, epsrel, result, neval, w)
 end
 
@@ -1116,7 +1116,7 @@ GSL documentation:
 > approximated as
 
 """
-function integration_fixed(func, result, w)
+function integration_fixed(func::F, result, w) where F
     ccall((:gsl_integration_fixed, libgsl), Cint, (Ref{gsl_function}, Ref{Cdouble}, Ref{gsl_integration_fixed_workspace}), func, result, w)
 end
 

--- a/src/gen/direct_wrappers/gsl_min_h.jl
+++ b/src/gen/direct_wrappers/gsl_min_h.jl
@@ -67,7 +67,7 @@ GSL documentation:
 > returns an error code of `GSL_EINVAL`.
 
 """
-function min_fminimizer_set(s, f, x_minimum, x_lower, x_upper)
+function min_fminimizer_set(s, f::gsl_function, x_minimum, x_lower, x_upper)
     ccall((:gsl_min_fminimizer_set, libgsl), Cint, (Ref{gsl_min_fminimizer}, Ref{gsl_function}, Cdouble, Cdouble, Cdouble), s, f, x_minimum, x_lower, x_upper)
 end
 
@@ -86,7 +86,7 @@ GSL documentation:
 > `f(x_minimum)`, `f(x_lower)` and `f(x_upper)`.
 
 """
-function min_fminimizer_set_with_values(s, f, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper)
+function min_fminimizer_set_with_values(s, f::gsl_function, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper)
     ccall((:gsl_min_fminimizer_set_with_values, libgsl), Cint, (Ref{gsl_min_fminimizer}, Ref{gsl_function}, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble, Cdouble), s, f, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper)
 end
 
@@ -301,7 +301,7 @@ end
 C signature:
 `int gsl_min_find_bracket(gsl_function *f,double *x_minimum,double * f_minimum, double *x_lower, double * f_lower, double *x_upper, double * f_upper, size_t eval_max)`
 """
-function min_find_bracket(f, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper, eval_max)
+function min_find_bracket(f::F, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper, eval_max) where F
     ccall((:gsl_min_find_bracket, libgsl), Cint, (Ref{gsl_function}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Csize_t), f, x_minimum, f_minimum, x_lower, f_lower, x_upper, f_upper, eval_max)
 end
 

--- a/src/gen/direct_wrappers/gsl_multiroots_h.jl
+++ b/src/gen/direct_wrappers/gsl_multiroots_h.jl
@@ -12,7 +12,7 @@
 C signature:
 `int gsl_multiroot_fdjacobian (gsl_multiroot_function * F, const gsl_vector * x, const gsl_vector * f, double epsrel, gsl_matrix * jacobian)`
 """
-function multiroot_fdjacobian(F, x, f, epsrel, jacobian)
+function multiroot_fdjacobian(F::Fn, x, f, epsrel, jacobian) where Fn
     ccall((:gsl_multiroot_fdjacobian, libgsl), Cint, (Ref{gsl_multiroot_function}, Ref{gsl_vector}, Ref{gsl_vector}, Cdouble, Ref{gsl_matrix}), F, x, f, epsrel, jacobian)
 end
 
@@ -81,7 +81,7 @@ GSL documentation:
 > is not modified by subsequent iterations.
 
 """
-function multiroot_fsolver_set(s, f, x)
+function multiroot_fsolver_set(s, f::gsl_multiroot_function, x)
     ccall((:gsl_multiroot_fsolver_set, libgsl), Cint, (Ref{gsl_multiroot_fsolver}, Ref{gsl_multiroot_function}, Ref{gsl_vector}), s, f, x)
 end
 

--- a/src/gen/direct_wrappers/gsl_multiroots_h.jl
+++ b/src/gen/direct_wrappers/gsl_multiroots_h.jl
@@ -242,7 +242,7 @@ end
 C signature:
 `int gsl_multiroot_fdfsolver_set (gsl_multiroot_fdfsolver * s, gsl_multiroot_function_fdf * fdf, const gsl_vector * x)`
 """
-function multiroot_fdfsolver_set(s, fdf, x)
+function multiroot_fdfsolver_set(s, fdf::gsl_multiroot_function_fdf, x)
     ccall((:gsl_multiroot_fdfsolver_set, libgsl), Cint, (Ref{gsl_multiroot_fdfsolver}, Ref{gsl_multiroot_function_fdf}, Ref{gsl_vector}), s, fdf, x)
 end
 

--- a/src/gen/direct_wrappers/gsl_roots_h.jl
+++ b/src/gen/direct_wrappers/gsl_roots_h.jl
@@ -66,7 +66,7 @@ GSL documentation:
 > `x_upper`\].
 
 """
-function root_fsolver_set(s, f, x_lower, x_upper)
+function root_fsolver_set(s, f::gsl_function, x_lower, x_upper)
     ccall((:gsl_root_fsolver_set, libgsl), Cint, (Ref{gsl_root_fsolver}, Ref{gsl_function}, Cdouble, Cdouble), s, f, x_lower, x_upper)
 end
 

--- a/src/gen/direct_wrappers/gsl_roots_h.jl
+++ b/src/gen/direct_wrappers/gsl_roots_h.jl
@@ -221,7 +221,7 @@ GSL documentation:
 > use the function and derivative `fdf` and the initial guess `root`.
 
 """
-function root_fdfsolver_set(s, fdf, root)
+function root_fdfsolver_set(s, fdf::gsl_function_fdf, root)
     ccall((:gsl_root_fdfsolver_set, libgsl), Cint, (Ref{gsl_root_fdfsolver}, Ref{gsl_function_fdf}, Cdouble), s, fdf, root)
 end
 

--- a/src/manual_wrappers.jl
+++ b/src/manual_wrappers.jl
@@ -729,3 +729,61 @@ function multiroot_fsolver_free(s::GSLMultirootFSolver)
     end
     return
 end
+
+@doc md"""
+$(Docs.doc(C.multiroot_fdfsolver_alloc))
+"""
+mutable struct GSLMultirootFDFSolver
+    ptr::Ptr{gsl_multiroot_fdfsolver}
+    param_ref
+    gsl_func::gsl_multiroot_function_fdf
+    function GSLMultirootFDFSolver(T, n)
+        s = new(multiroot_fdfsolver_alloc(T, n), nothing)
+        finalizer(multiroot_fdfsolver_free, s)
+        return s
+    end
+end
+export GSLMultirootFDFSolver
+
+Base.cconvert(::Type{Ref{gsl_multiroot_fdfsolver}}, s::GSLMultirootFDFSolver) = s
+Base.unsafe_convert(::Type{Ref{gsl_multiroot_fdfsolver}}, s::GSLMultirootFDFSolver) =
+    s.ptr
+Base.unsafe_convert(::Type{Ptr{gsl_multiroot_fdfsolver}}, s::GSLMultirootFDFSolver) =
+    s.ptr
+
+@doc md"""
+$(Docs.doc(C.multiroot_fdfsolver_set))
+"""
+function multiroot_fdfsolver_set(s::GSLMultirootFDFSolver,
+                                 (f, df, n)::NTuple{3,Any}, x)
+    s.gsl_func, s.param_ref = wrap_gsl_multiroot_function_fdf((f, df), n)
+    return C.multiroot_fdfsolver_set(s, s.gsl_func, x)
+end
+function multiroot_fdfsolver_set(s::GSLMultirootFDFSolver,
+                                 (f, df, fdf, n)::NTuple{4,Any}, x)
+    s.gsl_func, s.param_ref = wrap_gsl_multiroot_function_fdf((f, df, fdf), n)
+    return C.multiroot_fdfsolver_set(s, s.gsl_func, x)
+end
+function multiroot_fdfsolver_set(s::GSLMultirootFDFSolver,
+                                 f::gsl_multiroot_function_fdf, x)
+    s.gsl_func = f
+    s.param_ref = nothing
+    return C.multiroot_fdfsolver_set(s, s.gsl_func, x)
+end
+function multiroot_fdfsolver_set(s::Ptr{gsl_multiroot_fdfsolver}, f::gsl_multiroot_function_fdf, x)
+    return C.multiroot_fdfsolver_set(s, f, x)
+end
+
+@doc md"""
+$(Docs.doc(C.multiroot_fdfsolver_free))
+"""
+function multiroot_fdfsolver_free(s::Ptr{gsl_multiroot_fdfsolver})
+    C.multiroot_fdfsolver_free(s)
+end
+function multiroot_fdfsolver_free(s::GSLMultirootFDFSolver)
+    if s.ptr != C_NULL
+        C.multiroot_fdfsolver_free(s)
+        s.ptr = C_NULL
+    end
+    return
+end

--- a/src/manual_wrappers.jl
+++ b/src/manual_wrappers.jl
@@ -629,3 +629,53 @@ function root_fsolver_free(s::GSLRootFSolver)
     end
     return
 end
+
+@doc md"""
+$(Docs.doc(C.root_fdfsolver_alloc))
+"""
+mutable struct GSLRootFDFSolver
+    ptr::Ptr{gsl_root_fdfsolver}
+    param_ref
+    gsl_func::gsl_function_fdf
+    function GSLRootFDFSolver(T)
+        s = new(root_fdfsolver_alloc(T), nothing)
+        finalizer(root_fdfsolver_free, s)
+        return s
+    end
+end
+export GSLRootFDFSolver
+
+Base.cconvert(::Type{Ref{gsl_root_fdfsolver}}, s::GSLRootFDFSolver) = s
+Base.unsafe_convert(::Type{Ref{gsl_root_fdfsolver}}, s::GSLRootFDFSolver) = s.ptr
+Base.unsafe_convert(::Type{Ptr{gsl_root_fdfsolver}}, s::GSLRootFDFSolver) = s.ptr
+
+@doc md"""
+$(Docs.doc(C.root_fdfsolver_set))
+"""
+function root_fdfsolver_set(s::GSLRootFDFSolver,
+                            fdf::Union{NTuple{2,Any},NTuple{3,Any}}, root)
+    s.gsl_func, s.param_ref = wrap_gsl_function_fdf(fdf)
+    return C.root_fdfsolver_set(s, s.gsl_func, root)
+end
+function root_fdfsolver_set(s::GSLRootFDFSolver, f::gsl_function_fdf, root)
+    s.gsl_func = f
+    s.param_ref = nothing
+    return C.root_fdfsolver_set(s, s.gsl_func, root)
+end
+function root_fdfsolver_set(s::Ptr{gsl_root_fdfsolver}, f::gsl_function_fdf, root)
+    return C.root_fdfsolver_set(s, f, root)
+end
+
+@doc md"""
+$(Docs.doc(C.root_fdfsolver_free))
+"""
+function root_fdfsolver_free(s::Ptr{gsl_root_fdfsolver})
+    C.root_fdfsolver_free(s)
+end
+function root_fdfsolver_free(s::GSLRootFDFSolver)
+    if s.ptr != C_NULL
+        C.root_fdfsolver_free(s)
+        s.ptr = C_NULL
+    end
+    return
+end

--- a/src/manual_wrappers.jl
+++ b/src/manual_wrappers.jl
@@ -504,3 +504,79 @@ function cheb_free(cs::GSLCheb)
     end
     return
 end
+
+@doc md"""
+$(Docs.doc(C.min_fminimizer_alloc))
+"""
+mutable struct GSLMinFMinimizer
+    ptr::Ptr{gsl_min_fminimizer}
+    param_ref
+    gsl_func::gsl_function
+    function GSLMinFMinimizer(T)
+        s = new(min_fminimizer_alloc(T), nothing)
+        finalizer(min_fminimizer_free, s)
+        return s
+    end
+end
+export GSLMinFMinimizer
+
+Base.cconvert(::Type{Ref{gsl_min_fminimizer}}, s::GSLMinFMinimizer) = s
+Base.unsafe_convert(::Type{Ref{gsl_min_fminimizer}}, s::GSLMinFMinimizer) = s.ptr
+Base.unsafe_convert(::Type{Ptr{gsl_min_fminimizer}}, s::GSLMinFMinimizer) = s.ptr
+
+@doc md"""
+$(Docs.doc(C.min_fminimizer_set))
+"""
+function min_fminimizer_set(s::GSLMinFMinimizer, f::F,
+                            x_minimum, x_lower, x_upper) where F
+    s.gsl_func, s.param_ref = wrap_gsl_function(f)
+    return C.min_fminimizer_set(s, s.gsl_func, x_minimum, x_lower, x_upper)
+end
+function min_fminimizer_set(s::GSLMinFMinimizer, f::gsl_function,
+                            x_minimum, x_lower, x_upper)
+    s.gsl_func = f
+    s.param_ref = nothing
+    return C.min_fminimizer_set(s, s.gsl_func, x_minimum, x_lower, x_upper)
+end
+function min_fminimizer_set(s::Ptr{gsl_min_fminimizer}, f::gsl_function,
+                            x_minimum, x_lower, x_upper)
+    return C.min_fminimizer_set(s, f, x_minimum, x_lower, x_upper)
+end
+
+@doc md"""
+$(Docs.doc(C.min_fminimizer_set_with_values))
+"""
+function min_fminimizer_set_with_values(s::GSLMinFMinimizer, f::F, x_minimum, f_minimum,
+                                        x_lower, f_lower, x_upper, f_upper) where F
+    s.gsl_func, s.param_ref = wrap_gsl_function(f)
+    return C.min_fminimizer_set_with_values(s, s.gsl_func, x_minimum, f_minimum,
+                                            x_lower, f_lower, x_upper, f_upper)
+end
+function min_fminimizer_set_with_values(s::GSLMinFMinimizer, f::gsl_function, x_minimum,
+                                        f_minimum, x_lower, f_lower, x_upper, f_upper)
+    s.gsl_func = f
+    s.param_ref = nothing
+    return C.min_fminimizer_set_with_values(s, s.gsl_func, x_minimum,
+                                            f_minimum, x_lower, f_lower,
+                                            x_upper, f_upper)
+end
+function min_fminimizer_set_with_values(s::Ptr{gsl_min_fminimizer}, f::gsl_function,
+                                        x_minimum, f_minimum, x_lower, f_lower,
+                                        x_upper, f_upper)
+    return C.min_fminimizer_set_with_values(s, f, x_minimum, f_minimum, x_lower,
+                                            f_lower, x_upper, f_upper)
+end
+
+@doc md"""
+$(Docs.doc(C.min_fminimizer_free))
+"""
+function min_fminimizer_free(s::Ptr{gsl_min_fminimizer})
+    C.min_fminimizer_free(s)
+end
+function min_fminimizer_free(s::GSLMinFMinimizer)
+    if s.ptr != C_NULL
+        C.min_fminimizer_free(s)
+        s.ptr = C_NULL
+    end
+    return
+end

--- a/src/manual_wrappers.jl
+++ b/src/manual_wrappers.jl
@@ -679,3 +679,53 @@ function root_fdfsolver_free(s::GSLRootFDFSolver)
     end
     return
 end
+
+@doc md"""
+$(Docs.doc(C.multiroot_fsolver_alloc))
+"""
+mutable struct GSLMultirootFSolver
+    ptr::Ptr{gsl_multiroot_fsolver}
+    param_ref
+    gsl_func::gsl_multiroot_function
+    function GSLMultirootFSolver(T, n)
+        s = new(multiroot_fsolver_alloc(T, n), nothing)
+        finalizer(multiroot_fsolver_free, s)
+        return s
+    end
+end
+export GSLMultirootFSolver
+
+Base.cconvert(::Type{Ref{gsl_multiroot_fsolver}}, s::GSLMultirootFSolver) = s
+Base.unsafe_convert(::Type{Ref{gsl_multiroot_fsolver}}, s::GSLMultirootFSolver) = s.ptr
+Base.unsafe_convert(::Type{Ptr{gsl_multiroot_fsolver}}, s::GSLMultirootFSolver) = s.ptr
+
+@doc md"""
+$(Docs.doc(C.multiroot_fsolver_set))
+"""
+function multiroot_fsolver_set(s::GSLMultirootFSolver, (f, n), x)
+    s.gsl_func, s.param_ref = wrap_gsl_multiroot_function(f, n)
+    return C.multiroot_fsolver_set(s, s.gsl_func, x)
+end
+function multiroot_fsolver_set(s::GSLMultirootFSolver, f::gsl_multiroot_function, x)
+    s.gsl_func = f
+    s.param_ref = nothing
+    return C.multiroot_fsolver_set(s, s.gsl_func, x)
+end
+function multiroot_fsolver_set(s::Ptr{gsl_multiroot_fsolver},
+                               f::gsl_multiroot_function, x)
+    return C.multiroot_fsolver_set(s, f, x)
+end
+
+@doc md"""
+$(Docs.doc(C.multiroot_fsolver_free))
+"""
+function multiroot_fsolver_free(s::Ptr{gsl_multiroot_fsolver})
+    C.multiroot_fsolver_free(s)
+end
+function multiroot_fsolver_free(s::GSLMultirootFSolver)
+    if s.ptr != C_NULL
+        C.multiroot_fsolver_free(s)
+        s.ptr = C_NULL
+    end
+    return
+end

--- a/test/chebyshev.jl
+++ b/test/chebyshev.jl
@@ -1,0 +1,20 @@
+using Test
+using GSL
+
+
+@testset "Chebyshev" begin
+    # tests from FastChebInterp.jl
+    f = x -> exp(x) / (1 + 2x^2)
+    f′ = x -> f(x) * (1 - 4x/(1 + 2x^2))
+    lb, ub = (-0.3, 0.9)
+    x = 0.2
+
+    p = GSLCheb(48)
+
+    cheb_init(p, f, lb, ub)
+    @test !(cheb_eval_n(p, 10, x) ≈ f(x))
+    @test cheb_eval(p, x) ≈ f(x)
+    cheb_init(p, f′, lb, ub)
+    @test !(cheb_eval_n(p, 10, x) ≈ f′(x))
+    @test cheb_eval(p, x) ≈ f′(x)
+end

--- a/test/minimization.jl
+++ b/test/minimization.jl
@@ -1,0 +1,31 @@
+using Test
+using GSL
+
+@testset "1d minimization" begin
+    f = x -> cos(x) + one(x)
+    @testset "fminimizer $name" for (alg, name) in [
+        (gsl_min_fminimizer_goldensection, "goldensection")
+        (gsl_min_fminimizer_brent, "brent")
+        (gsl_min_fminimizer_quad_golden, "quad-golden")
+    ]
+        m, m_exact = 2.0, pi
+        a, b = 0.0, 6.0
+        epsabs, epsrel = 1e-3, 0e-0
+        s = GSLMinFMinimizer(alg)
+        @test min_fminimizer_name(s) == name
+        min_fminimizer_set(s, f, m, a, b)
+
+        maxiter = 100
+        status = converged = 0
+        for i in 1:maxiter
+            status = min_fminimizer_iterate(s)
+            m = min_fminimizer_x_minimum(s)
+            a = min_fminimizer_x_lower(s)
+            b = min_fminimizer_x_upper(s)
+            converged = min_test_interval(a, b, epsabs, epsrel)
+            status == converged == GSL_SUCCESS && break
+        end
+        @test status == converged == GSL_SUCCESS
+        @test m ≈ m_exact atol=epsabs rtol=epsrel
+    end
+end

--- a/test/numdiff.jl
+++ b/test/numdiff.jl
@@ -1,7 +1,7 @@
 using GSL
 using Test
 
-func(x) = x^3    
+func(x) = x^3
 
 @testset "Numerical differentiation" begin
     x = 1.0
@@ -14,6 +14,9 @@ func(x) = x^3
         df,ddf = Cdouble[0], Cdouble[0]
         deriv(@gsl_function(func), x, h, df, ddf)
         @test abs(df_dx - df[]) <= ddf[] <= d2f_dx2*h/2 + 2eps()/h
+
+        df,ddf = Cdouble[0], Cdouble[0]
+        deriv(func, x, h, df, ddf)
+        @test abs(df_dx - df[]) <= ddf[] <= d2f_dx2*h/2 + 2eps()/h
     end
 end
-

--- a/test/quadrature.jl
+++ b/test/quadrature.jl
@@ -19,3 +19,23 @@ fquad = x -> x^1.5
 
     integration_cquad_workspace_free(ws)
 end
+
+@testset "Quadrature (closure)" begin
+    # Make sure this is actually a closure
+    fquad = let n = 1.5
+        x -> x^n
+    end
+    ws_size = 100
+    ws = integration_cquad_workspace_alloc(ws_size)
+
+    a = 0
+    b = 1
+    result = Cdouble[0]
+    abserr = Cdouble[0]
+    nevals = Csize_t[0]
+    integration_cquad(fquad, a, b, 1e-10, 1e-10, ws, result, abserr, nevals)
+
+    @test abs(result[] - 1/2.5) < abserr[]
+
+    integration_cquad_workspace_free(ws)
+end

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -64,6 +64,33 @@ fdf2 = @gsl_function_fdf(myfun, myfun_deriv)
         end
     end
 
+    @testset "Secant method wrapper" begin
+        T = gsl_root_fsolver_bisection
+        @testset "alloc/free" begin
+            A = GSLRootFSolver(T)
+        end
+        @testset "Solve" begin
+            solver = GSLRootFSolver(T)
+            root_fsolver_set(solver, myfun, -10, 10)
+
+            status = GSL_CONTINUE
+            maxiter = 40
+            iter = 0
+            while status == GSL_CONTINUE
+                root_fsolver_iterate(solver)
+                x = root_fsolver_root(solver)
+                status = root_test_residual(myfun(x), 1e-10)
+                iter += 1
+                if iter==maxiter
+                    error("No convergence")
+                end
+            end
+            @test status == GSL_SUCCESS
+            x = root_fsolver_root(solver)
+            @test abs(myfun(x)) < 1e-10
+        end
+    end
+
     @testset "Newton's method" begin               
         T = gsl_root_fdfsolver_newton
 

--- a/test/rootfinding.jl
+++ b/test/rootfinding.jl
@@ -142,4 +142,52 @@ fdf2 = @gsl_function_fdf(myfun, myfun_deriv)
         end       
         
     end
+
+    @testset "Newton's method wrapper" begin
+        T = gsl_root_fdfsolver_newton
+
+        @testset "alloc/free" begin
+            A = GSLRootFDFSolver(T)
+        end
+
+        @testset "Solve" begin
+            solver = GSLRootFDFSolver(T)
+            root_fdfsolver_set(solver, (myfun, myfun_deriv, myfun_fdf), 5)
+
+            status = GSL_CONTINUE
+            iter, maxiter = 0,20
+            while status == GSL_CONTINUE
+                root_fdfsolver_iterate(solver)
+                x = root_fdfsolver_root(solver)
+                status = root_test_residual(myfun(x), 1e-10)
+                iter += 1
+                if iter==maxiter
+                    error("No convergence")
+                end
+            end
+            @test status == GSL_SUCCESS
+            x = root_fdfsolver_root(solver)
+            @test abs(myfun(x)) < 1e-10
+        end
+
+        @testset "Solve / simplestruct" begin
+            solver = GSLRootFDFSolver(T)
+            root_fdfsolver_set(solver, (myfun, myfun_deriv), 5)
+
+            status = GSL_CONTINUE
+            iter, maxiter = 0,20
+            while status == GSL_CONTINUE
+                root_fdfsolver_iterate(solver)
+                x = root_fdfsolver_root(solver)
+                status = root_test_residual(myfun(x), 1e-10)
+                iter += 1
+                if iter==maxiter
+                    error("No convergence")
+                end
+            end
+            @test status == GSL_SUCCESS
+            x = root_fdfsolver_root(solver)
+            @test abs(myfun(x)) < 1e-10
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ Random.seed!(1)
     include("rootfinding.jl")
     include("specfunc.jl")
     include("chebyshev.jl")
+    include("minimization.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,15 +6,15 @@ using SpecialFunctions
 Random.seed!(1)
 
 @testset "GSL" begin
-    include("error.jl")    
+    include("error.jl")
     include("hypergeom.jl")
     include("interp.jl")
     include("legendre.jl")
-    include("multidim_rootfinding.jl")    
+    include("multidim_rootfinding.jl")
     include("numdiff.jl")
     include("quadrature.jl")
-    include("rng.jl")    
+    include("rng.jl")
     include("rootfinding.jl")
     include("specfunc.jl")
+    include("chebyshev.jl")
 end
-


### PR DESCRIPTION
This only cover a few of the functions (the ones that have macros created for them) and all of their uses. There are still many other callback types and objects that are not covered.

All the new interfaces should be restricted to when it is actually safe to do so. The old interface remains in place for backward compatibility (it may be broken for a few cases if the user have defined their own `cconvert`/`unsafe_convert` methods on the GSL pointer type but I think those usecases can be safely ignored.)

The auto generation script has not been updated. There are some changes to the code that can't easily be done automatically though most of those should not be exported function anymore (there's method explicitly defined in GSL module that hides the C module reexport) so that could be fixed reasonably easily.

The implementation for some functions (the "managed" ones, e.g. `cheb_init` are not fully optimum) and there are some cases where another one allocation could be shaved off. Since these are mainly set-once-use-multiple time allocations I didn't feel like optimizing it while making the code a bit more ugly at the moment....
