### PR TITLE
ci: test with [1.3, lts, 1]

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.3'  # compat require
+          - 'lts'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,10 +27,18 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-13 # Intel
           - windows-latest
         arch:
           - x64
+        include:
+          # macos-latest -> Apple Silicon (Need julia >= v1.8)
+          - os: macos-latest
+            arch: 'aarch64'
+            version: 'lts'
+          - os: macos-latest
+            arch: 'aarch64'
+            version: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/cache@v2


### PR DESCRIPTION
- test with `[1.3, lts, 1]`
	compat require julia >= v1.3
	https://github.com/JuliaMath/GSL.jl/blob/ee433846fee5a2b6402696e822750bf917f6eabf/Project.toml#L15
- test with `macos-13-x64` and `macos-latest-aarch64`
